### PR TITLE
fix: speed up common-case simple {key: value, key2: value2} checks

### DIFF
--- a/where-filter.js
+++ b/where-filter.js
@@ -215,6 +215,8 @@ function whereFilter(where) {
 
 	return function(obj) {
 		return keys.every(function(key) {
+			if (key !== AND && key !== OR && where[key] === obj[key]) return true;
+
 			if (key === AND || key === OR) {
 				if (Array.isArray(where[key])) {
 					if (key === AND) {


### PR DESCRIPTION
faster testing of simple `{key1: value1, key2: value2, ...}` type conditionals for simple values (string, number, boolean, etc, not objects or arrays)