### PR TITLE
fix: (PERF-2032) fix fast-path and/or checking

### DIFF
--- a/where-filter.js
+++ b/where-filter.js
@@ -215,7 +215,8 @@ function whereFilter(where) {
 
 	return function(obj) {
 		return keys.every(function(key) {
-			if (key !== AND && key !== OR && where[key] === obj[key]) return true;
+			// the expected value can identity-match only if value is string/number/boolean/null
+			if (where[key] === obj[key]) return true;
 
 			if (key === AND || key === OR) {
 				if (Array.isArray(where[key])) {


### PR DESCRIPTION
fix the fast-path and/or handling for non-array values, eg `{and: 3}` is not an error, it matches if `obj.and === 3`