### PR TITLE
fix: (PERF-3016) build and publish main, not master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - main
           requires:
             - prep
             - lint


### PR DESCRIPTION
tag, build and publish the `main` branch, not `master`