### PR TITLE
fix: (PERF-3012) fix regex patterns to allow sql wildcard escaping

### DIFF
--- a/test/where-filter.test.js
+++ b/test/where-filter.test.js
@@ -51,6 +51,10 @@ context('whereFilter', () => {
 			// note that sql anchors LIKE patterns at both ^ and $, but where-filter does not
 			assert.equal(whereFilter({x: {like: 'foo%'}})({x: 'pad foobar pad'}), true);
 
+			assert.equal(whereFilter({x: {like: '%bar'}})({x: 'bar'}), true);
+			assert.equal(whereFilter({x: {like: '%bar'}})({x: 'foobar'}), true);
+			assert.equal(whereFilter({x: {like: '%bar'}})({x: 'foo'}), false);
+
 			assert.equal(whereFilter({x: {like: 'fo_'}})({x: 'foo'}), true);
 			assert.equal(whereFilter({x: {like: 'fo_'}})({x: 'foobar'}), true);
 			assert.equal(whereFilter({x: {like: 'fo_'}})({x: 'bar'}), false);

--- a/test/where-filter.test.js
+++ b/test/where-filter.test.js
@@ -78,6 +78,7 @@ context('whereFilter', () => {
 			const metachars = '.*+?^=!:${}()|\[\]\/\\';
 			const escapedMetachars = metachars.replace(/(.)/g, '\\$1');
 			assert.equal(whereFilter({x: {like: escapedMetachars}})({x: `${metachars} pad`}), true);
+			assert.equal(whereFilter({x: {like: escapedMetachars}})({x: metachars.replace('[', 'x')}), false);
 
 			assert.equal(whereFilter({x: {like: 'foo\\%bar'}})({x: 'foo%bar'}), true);
 			assert.equal(whereFilter({x: {like: 'foo\\%bar'}})({x: 'foo bar'}), false);

--- a/test/where-filter.test.js
+++ b/test/where-filter.test.js
@@ -29,17 +29,31 @@ context('whereFilter', () => {
 		assert.equal(array.filter(whereFilter({symbol: {neq: 'IBM'}})).length, 3);
 	});
 
-	it('should handle simple named relational operators', () => {
-		assert.equal(array.filter(whereFilter({qty: {eq: 10}})).length, 2);
-		assert.equal(array.filter(whereFilter({qty: {eq: 60}})).length, 1);
-
-		assert.equal(array.filter(whereFilter({qty: {neq: 10}})).length, 3);
-		assert.equal(array.filter(whereFilter({qty: {neq: 60}})).length, 4);
-
+	it('should handle other simple named relational operators', () => {
+		// lt/lte/gt/gte
 		assert.equal(array.filter(whereFilter({qty: {lt: 60}})).length, 2);
 		assert.equal(array.filter(whereFilter({qty: {lte: 60}})).length, 3);
 		assert.equal(array.filter(whereFilter({qty: {gt: 60}})).length, 1);
 		assert.equal(array.filter(whereFilter({qty: {gte: 60}})).length, 2);
+
+		// between
+		assert.equal(array.filter(whereFilter({qty: {between: [10, 60]}})).length, 3);
+
+		// like/nlike/ilike/nilike
+		assert.equal(array.filter(whereFilter({symbol: {like: 'OOG'}})).length, 1);
+		assert.equal(array.filter(whereFilter({symbol: {like: 'oog'}})).length, 0);
+		assert.equal(array.filter(whereFilter({symbol: {nlike: 'OOG'}})).length, 4);
+		assert.equal(array.filter(whereFilter({symbol: {nlike: 'oog'}})).length, 5);
+		assert.equal(array.filter(whereFilter({symbol: {ilike: 'OoG'}})).length, 1);
+		assert.equal(array.filter(whereFilter({symbol: {nilike: 'oOg'}})).length, 4);
+
+		// like with regex (it's just looking for any character that matches)
+		assert.equal(array.filter(whereFilter({id: {like: '\\w+\.\\d'}})).length, 5);
+		assert.equal(array.filter(whereFilter({symbol: {like: '\\w+\.\\d'}})).length, 0);
+
+		// inq, nin
+		assert.equal(array.filter(whereFilter({symbol: {inq: ['IBM', 'GOOG']}})).length, 3);
+		assert.equal(array.filter(whereFilter({symbol: {nin: ['IBM', 'GOOG']}})).length, 2);
 	});
 
 	it('should handle simple query with dotted path', () => {

--- a/test/where-filter.test.js
+++ b/test/where-filter.test.js
@@ -74,6 +74,15 @@ context('whereFilter', () => {
 			assert.equal(array.filter(whereFilter({symbol: {like: 'AAA*'}})).length, 1);
 		});
 
+		it('should match PCRE regular expression patterns', () => {
+			assert.equal(whereFilter({x: {like: 'f\\o\\w+#\\d'}})({x: 'foobar#5'}), true);
+			assert.equal(whereFilter({x: {like: 'f\\o\\w{4}#\\d'}})({x: 'foobar#5'}), true);
+			assert.equal(whereFilter({x: {like: 'f\\o\\w{1,10}#\\d'}})({x: 'foobar#5'}), true);
+
+			assert.equal(whereFilter({x: {like: 'f\\o\\w{1,2}#\\d'}})({x: 'foobar#5'}), false);
+			assert.equal(whereFilter({x: {like: 'f\\o\\w+#\\d\\d'}})({x: 'foobar#5'}), false);
+		});
+
 		it('should match verbatim regular expression metacharacters', () => {
 			const metachars = '.*+?^=!:${}()|\[\]\/\\';
 			const escapedMetachars = metachars.replace(/(.)/g, '\\$1');

--- a/where-filter.js
+++ b/where-filter.js
@@ -100,7 +100,6 @@ function toRegExp(pattern) {
 	// JavaScript/Guide/Regular_Expressions#Writing_a_Regular_Expression_Pattern
 	// pattern = pattern.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1');
 
-	const metachars = '.*+?^=!:${}()|\[\]\/\\';
 	for (let i = 0, n = pattern.length; i < n; i++) {
 		const char = pattern.charAt(i);
 

--- a/where-filter.js
+++ b/where-filter.js
@@ -98,25 +98,25 @@ function toRegExp(pattern) {
 	// Escaping user input to be treated as a literal string within a regular expression
 	// https://developer.mozilla.org/en-US/docs/Web/
 	// JavaScript/Guide/Regular_Expressions#Writing_a_Regular_Expression_Pattern
-	pattern = pattern.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1');
+	// pattern = pattern.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1');
+
+	const metachars = '.*+?^=!:${}()|\[\]\/\\';
 	for (let i = 0, n = pattern.length; i < n; i++) {
 		const char = pattern.charAt(i);
 
 		if (char === '\\') {
 			i++; // Skip to next char
-			if (i < n) {
-				regex += pattern.charAt(i);
-			}
-			continue;
+			// match backslash-escaped chars verbatim, escape them in the regex too
+			// but a trailing backslash only matches itself
+			regex += i < n ? '\\' + pattern.charAt(i) : '\\\\';
 		} else if (char === '%') {
+			// sql substring wildcard
 			regex += '.*';
 		} else if (char === '_') {
+			// sql single-char wildcard
 			regex += '.';
-		} else if (char === '.') {
-			regex += '\\.';
-		} else if (char === '*') {
-			regex += '\\*';
 		} else {
+			// all other chars, including metachars, included in the regex as-is
 			regex += char;
 		}
 	}


### PR DESCRIPTION
* fix the regex pattern handling used by `like`, `ilike` etc to support sql wildcard escaping `\%` and `\_`
* test sql wildcard handling
* test regex metacharacter escaping
* spot-check regex handling
